### PR TITLE
honeycombio: add support for environment-wide assets

### DIFF
--- a/docs/honeycombio.md
+++ b/docs/honeycombio.md
@@ -1,13 +1,13 @@
 ### Use with Honeycomb.io
 
-Example:
+#### Example
 
-```
+```sh
 export HONEYCOMB_API_KEY=MYAPIKEY
 ./terraformer import honeycombio --resources=board,trigger
 ```
 
-List of supported Honeycomb resources:
+#### List of supported Honeycomb resources
 
 * `board`
   * `honeycombio_board`
@@ -22,3 +22,14 @@ List of supported Honeycomb resources:
   * `honeycombio_slo`
   * `honeycombio_burn_alert`
   * `honeycombio_derived_column`
+
+#### A note about Environment-wide assets
+
+If no datasets are specified via the `--datasets` argument, and the API key is *not* for a Honeycomb Classic environment, the `__all__` dataset for Environment-wide assets (e.g. derived columns, boards) will be appended to the dataset list.
+
+If you wish to import a specific list of datasets *including* environment-wide assets (e.g. derived columns, boards) you must add `__all__` to the list of provided datasets.
+
+```sh
+export HONEYCOMB_API_KEY=MYAPIKEY
+./terraformer import honeycombio --resources=derived_column,board --datasets=__all__,my.service
+```

--- a/providers/honeycombio/board.go
+++ b/providers/honeycombio/board.go
@@ -14,20 +14,25 @@ type BoardGenerator struct {
 func (g *BoardGenerator) InitResources() error {
 	client, err := g.newClient()
 	if err != nil {
-		return fmt.Errorf("unable to list Honeycomb boards: %v", err)
+		return fmt.Errorf("unable to initialize Honeycomb client: %v", err)
 	}
 
 	boards, err := client.Boards.List(context.TODO())
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to list Honeycomb boards: %v", err)
 	}
 
 	for _, board := range boards {
+		// all of a board's queries must be in our list of target datasets or we don't import it
 		onlyValidDatasets := true
 		for _, query := range board.Queries {
-			_, present := g.datasetMap[query.Dataset]
-			if !present {
+			if query.Dataset == "" {
+				// assume an unset dataset is an environment-wide query
+				query.Dataset = environmentWideDatasetSlug
+			}
+			if _, exists := g.datasets[query.Dataset]; !exists {
 				onlyValidDatasets = false
+				break
 			}
 		}
 

--- a/providers/honeycombio/burn_alert.go
+++ b/providers/honeycombio/burn_alert.go
@@ -17,16 +17,18 @@ func (g *BurnAlertGenerator) InitResources() error {
 		return fmt.Errorf("unable to initialize Honeycomb client: %v", err)
 	}
 
-	ctx := context.TODO()
-
 	for _, dataset := range g.datasets {
-		slos, err := client.SLOs.List(ctx, dataset.Slug)
+		if dataset.Slug == environmentWideDatasetSlug {
+			// environment-wide Burn Alerts are not supported
+			continue
+		}
+		slos, err := client.SLOs.List(context.TODO(), dataset.Slug)
 		if err != nil {
-			return fmt.Errorf("unable to list Honeycomb SLOs for dataset %s: %v", dataset.Slug, err)
+			return fmt.Errorf("unable to list Honeycomb SLOs for dataset %q: %v", dataset.Slug, err)
 		}
 
 		for _, slo := range slos {
-			bas, _ := client.BurnAlerts.ListForSLO(ctx, dataset.Slug, slo.ID)
+			bas, _ := client.BurnAlerts.ListForSLO(context.TODO(), dataset.Slug, slo.ID)
 			for _, ba := range bas {
 				g.Resources = append(g.Resources, terraformutils.NewResource(
 					ba.ID,

--- a/providers/honeycombio/column.go
+++ b/providers/honeycombio/column.go
@@ -17,10 +17,11 @@ func (g *ColumnGenerator) InitResources() error {
 		return fmt.Errorf("unable to initialize Honeycomb client: %v", err)
 	}
 
-	ctx := context.TODO()
-
 	for _, dataset := range g.datasets {
-		columns, err := client.Columns.List(ctx, dataset.Slug)
+		if dataset.Slug == environmentWideDatasetSlug {
+			continue
+		}
+		columns, err := client.Columns.List(context.TODO(), dataset.Slug)
 		if err != nil {
 			return fmt.Errorf("unable to list Honeycomb columns for dataset %s: %v", dataset.Slug, err)
 		}

--- a/providers/honeycombio/dataset.go
+++ b/providers/honeycombio/dataset.go
@@ -11,12 +11,16 @@ type DatasetGenerator struct {
 }
 
 func (g *DatasetGenerator) InitResources() error {
+	// client is not used but initializing the client populates `g.datasets`
 	_, err := g.newClient()
 	if err != nil {
 		return fmt.Errorf("unable to initialize Honeycomb client: %v", err)
 	}
 
 	for _, dataset := range g.datasets {
+		if dataset.Slug == environmentWideDatasetSlug {
+			continue
+		}
 		g.Resources = append(g.Resources, terraformutils.NewResource(
 			dataset.Slug,
 			dataset.Slug,

--- a/providers/honeycombio/derived_column.go
+++ b/providers/honeycombio/derived_column.go
@@ -17,12 +17,10 @@ func (g *DerivedColumnGenerator) InitResources() error {
 		return fmt.Errorf("unable to initialize Honeycomb client: %v", err)
 	}
 
-	ctx := context.TODO()
-
 	for _, dataset := range g.datasets {
-		columns, err := client.DerivedColumns.List(ctx, dataset.Slug)
+		columns, err := client.DerivedColumns.List(context.TODO(), dataset.Slug)
 		if err != nil {
-			return fmt.Errorf("unable to list Honeycomb derived columns for dataset %s: %v", dataset.Slug, err)
+			return fmt.Errorf("unable to list Honeycomb derived columns for dataset %q: %v", dataset.Slug, err)
 		}
 
 		for _, column := range columns {

--- a/providers/honeycombio/honeycomb_provider.go
+++ b/providers/honeycombio/honeycomb_provider.go
@@ -23,7 +23,7 @@ import (
 )
 
 const honeycombDefaultURL = "https://api.honeycomb.io"
-const honeycombTerraformerProviderVersion = "0.0.1"
+const honeycombTerraformerProviderVersion = "0.0.2"
 
 type HoneycombProvider struct { //nolint
 	terraformutils.Provider

--- a/providers/honeycombio/query_annotation.go
+++ b/providers/honeycombio/query_annotation.go
@@ -24,8 +24,15 @@ func (g *QueryAnnotationGenerator) InitResources() error {
 
 	for _, board := range boards {
 		for _, query := range board.Queries {
-			_, datasetSelected := g.datasetMap[query.Dataset]
-			if datasetSelected && query.QueryAnnotationID != "" {
+			if query.QueryAnnotationID == "" {
+				continue
+			}
+
+			if query.Dataset == "" {
+				// assume unset dataset is an environment-wide query
+				query.Dataset = g.environmentWideDataset().Name
+			}
+			if _, exists := g.datasets[query.Dataset]; exists {
 				g.Resources = append(g.Resources, terraformutils.NewResource(
 					query.QueryAnnotationID,
 					query.QueryAnnotationID,

--- a/providers/honeycombio/slo.go
+++ b/providers/honeycombio/slo.go
@@ -20,6 +20,10 @@ func (g *SLOGenerator) InitResources() error {
 	ctx := context.TODO()
 
 	for _, dataset := range g.datasets {
+		if dataset.Slug == environmentWideDatasetSlug {
+			// environment-wide SLOs are not supported
+			continue
+		}
 		slos, err := client.SLOs.List(ctx, dataset.Slug)
 		if err != nil {
 			return fmt.Errorf("unable to list Honeycomb SLOs for dataset %s: %v", dataset.Slug, err)

--- a/providers/honeycombio/trigger.go
+++ b/providers/honeycombio/trigger.go
@@ -17,10 +17,12 @@ func (g *TriggerGenerator) InitResources() error {
 		return fmt.Errorf("unable to initialize Honeycomb client: %v", err)
 	}
 
-	ctx := context.TODO()
-
 	for _, dataset := range g.datasets {
-		triggers, err := client.Triggers.List(ctx, dataset.Slug)
+		if dataset.Slug == environmentWideDatasetSlug {
+			// environment-wide Triggers are not supported
+			continue
+		}
+		triggers, err := client.Triggers.List(context.TODO(), dataset.Slug)
 		if err != nil {
 			return fmt.Errorf("unable to list Honeycomb triggers for dataset %s: %v", dataset.Slug, err)
 		}


### PR DESCRIPTION
Adds support for environment-wide assets to the honeycombio provider.

Also cleans up the double-accounting of datasets into a single data structure, along with a few idiomatic Go things.